### PR TITLE
Fix to handle timestamp precision in generator

### DIFF
--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -61,7 +61,7 @@ module ULID
     end
 
     def millisecond_time
-      (@time.to_f * 1_000).to_i
+      (@time.to_r * 1_000).to_i
     end
 
     # THIS IS CORRECT (to the ULID spec)

--- a/spec/ulid_spec.rb
+++ b/spec/ulid_spec.rb
@@ -24,6 +24,12 @@ describe ULID do
       expect(ULID.at(KNOWN_TIME)).to be_a_valid_ulid
     end
 
+    it 'handles timestamp as the milliseconds precision' do
+      expect(ULID.at(Time.parse('2016-07-30 22:36:16.001000000 UTC'))).to start_with('01ARYZ6RR1')
+      expect(ULID.at(Time.parse('2016-07-30 22:36:16.002000000 UTC'))).to start_with('01ARYZ6RR2')
+      expect(ULID.at(Time.parse('2016-07-30 22:36:16.003000000 UTC'))).to start_with('01ARYZ6RR3')
+    end
+
   end
 
   describe '.time' do


### PR DESCRIPTION
Hi! currently this gem looks having same issue as https://github.com/rafaelsales/ulid/issues/22 in generator

So fixed with same way as https://github.com/rafaelsales/ulid/pull/23