### PR TITLE
Use Enumerable#to_h to avoid extra allocation

### DIFF
--- a/lib/ulid/constants.rb
+++ b/lib/ulid/constants.rb
@@ -15,7 +15,7 @@ module ULID
 
     # Byte to index table for O(1) lookups when unmarshaling.
     # We rely on nil as sentinel value for invalid indexes.
-    B32REF = Hash[ ENCODING.split('').each_with_index.to_a ]
+    B32REF = ENCODING.split('').each_with_index.to_h
   end
 end
 


### PR DESCRIPTION
We can avoid extra allocation by directly calling `#to_h` on `ENCODING.split('').each_with_index` instead of first converting it to an array and then converting it to a hash.

This is not a Hot path for this library as constants are generated only on load. Please feel free to close the PR if this qualifies as a cosmetic change.