### PR TITLE
Ensure compatibility with `--enable-frozen-string-literal`

### DIFF
--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -14,7 +14,7 @@ module ULID
 
       id = @bytes.bytes
 
-      output = ''
+      output = +''
 
       # Base32 encodes 5 bits of each byte of the input in each byte of the
       # output. That means each input byte produces >1 output byte and some


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205

In Ruby 3.4 string literals will be "chilled" by default. Meaning they are still mutable, but will pretend to be frozen, and emit a warning when mutated.

Then a later version of Ruby will default to frozen string literals.

NB: I'd happily add CI coverage but https://github.com/abachman/ulid-ruby/pull/7 would be needed first.