### PR TITLE
Optimize encode32 and decode32

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -55,7 +55,7 @@ module ULID
   #   ULID.time '0009A0QS00SGEFTGMFFEAS6B9A' #=> 1970-04-26 17:46:40 UTC
   #
   def self.time(ulid)
-    Identifier.new(ulid).time.utc
+    Identifier.new(ulid).time
   end
 
   # Get the first possible ULID string for the given time in sort order ascending.
@@ -81,6 +81,4 @@ module ULID
   def self.max_ulid_at(at_time)
     Identifier.new(at_time, MAX_ENTROPY).ulid
   end
-
 end
-

--- a/lib/ulid/constants.rb
+++ b/lib/ulid/constants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ULID
   module Constants
     # smallest representable time
@@ -10,12 +12,19 @@ module ULID
     # largest possible seed value
     MAX_ENTROPY = ([255] * 10).pack('C' * 10)
 
-    # Crockford's Base32. Alphabet portion is missing I, L, O, and U.
-    ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    # Crockford's Base32 (https://www.crockford.com/base32.html) Differs from Base32 in the following ways:
+    # * Excludes I, L, O and U
+    # * Aliases O to 0
+    # * Aliases I and L to 1
+    # * Uses U * ~ $ and = for appended checksums
+    #
+    # For simplicity, we use the RFC4648 Base32 encoding and convert to Crockford's Base32 with a simple translate
+    # However, we aren't supporting checksums nor the aliased characters
+    #
+    # B32_CROCKFORD_CHARS = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    # B32_RCF4648_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
 
-    # Byte to index table for O(1) lookups when unmarshaling.
-    # We rely on nil as sentinel value for invalid indexes.
-    B32REF = Hash[ ENCODING.split('').each_with_index.to_a ]
+    B32_CROCKFORD_FRAGMENT = "JKMNPQRSTVWXYZ"
+    B32_RCF4648_FRAGMENT = "ijklmnopqrstuv" # downcase becase .to_s(32) is always lowercase
   end
 end
-

--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -9,8 +9,9 @@ module ULID
 
     # returns the binary ULID as Base32 encoded string.
     def encode32
-      (hi, lo) = bytes.unpack("Q>Q>")
-      value = (hi << 64) | lo
+      high = bytes.unpack1("Q>")
+      low = bytes.unpack1("@8Q>")
+      value = (high << 64) | low
 
       # use the RFC4648 Base32 encoding and convert to Crockford's Base32 with a simple translate
       # assumes that the value is a 128-bit integer

--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -1,84 +1,37 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 require 'ulid/constants'
 
 module ULID
-
   module Generate
     include Constants
 
     # returns the binary ULID as Base32 encoded string.
     def encode32
-      # Optimized unrolled loop ahead.
-      # From https://github.com/RobThree/NUlid
-      # via https://github.com/oklog/ulid/blob/c3c01856f7e43fa64133819126887124d5f05e39/ulid.go#L154
+      (hi, lo) = bytes.unpack("Q>Q>")
+      value = (hi << 64) | lo
 
-      id = @bytes.bytes
+      # use the RFC4648 Base32 encoding and convert to Crockford's Base32 with a simple translate
+      # assumes that the value is a 128-bit integer
+      # also assumes that .to_s(32) is lowercase
+      b32 = value.to_s(32)
+      b32.tr!(B32_RCF4648_FRAGMENT, B32_CROCKFORD_FRAGMENT)
+      b32.upcase!
 
-      output = +''
+      return "0#{b32}" if b32.length == 25
 
-      # Base32 encodes 5 bits of each byte of the input in each byte of the
-      # output. That means each input byte produces >1 output byte and some
-      # output bytes encode parts of multiple input bytes.
-      #
-      # The end result is a human / URL friendly output string that can be
-      # decoded into the original bytes.
-
-      # 10 byte timestamp
-      output << ENCODING[(id[0]&224)>>5]
-      output << ENCODING[id[0]&31]
-      output << ENCODING[(id[1]&248)>>3]
-      output << ENCODING[((id[1]&7)<<2)|((id[2]&192)>>6)]
-      output << ENCODING[(id[2]&62)>>1]
-      output << ENCODING[((id[2]&1)<<4)|((id[3]&240)>>4)]
-      output << ENCODING[((id[3]&15)<<1)|((id[4]&128)>>7)]
-      output << ENCODING[(id[4]&124)>>2]
-      output << ENCODING[((id[4]&3)<<3)|((id[5]&224)>>5)]
-      output << ENCODING[id[5]&31]
-
-      # 16 bytes of entropy
-      output << ENCODING[(id[6]&248)>>3]
-      output << ENCODING[((id[6]&7)<<2)|((id[7]&192)>>6)]
-      output << ENCODING[(id[7]&62)>>1]
-      output << ENCODING[((id[7]&1)<<4)|((id[8]&240)>>4)]
-      output << ENCODING[((id[8]&15)<<1)|((id[9]&128)>>7)]
-      output << ENCODING[(id[9]&124)>>2]
-      output << ENCODING[((id[9]&3)<<3)|((id[10]&224)>>5)]
-      output << ENCODING[id[10]&31]
-      output << ENCODING[(id[11]&248)>>3]
-      output << ENCODING[((id[11]&7)<<2)|((id[12]&192)>>6)]
-      output << ENCODING[(id[12]&62)>>1]
-      output << ENCODING[((id[12]&1)<<4)|((id[13]&240)>>4)]
-      output << ENCODING[((id[13]&15)<<1)|((id[14]&128)>>7)]
-      output << ENCODING[(id[14]&124)>>2]
-      output << ENCODING[((id[14]&3)<<3)|((id[15]&224)>>5)]
-      output << ENCODING[id[15]&31]
-
-      output
+      b32
     end
 
     def random_bytes
       SecureRandom.random_bytes(10)
     end
 
-    def millisecond_time
-      (@time.to_r * 1_000).to_i
-    end
-
     # THIS IS CORRECT (to the ULID spec)
     def time_bytes
-      id = []
-
-      t = millisecond_time
-
-      # via https://github.com/oklog/ulid/blob/c3c01856f7e43fa64133819126887124d5f05e39/ulid.go#L295
-      id << [t >> 40].pack('c')
-      id << [t >> 32].pack('c')
-      id << [t >> 24].pack('c')
-      id << [t >> 16].pack('c')
-      id << [t >> 8].pack('c')
-      id << [t].pack('c')
-
-      id.join
+      epoch_ms = (time.to_f * 1000).to_i
+      [epoch_ms].pack("Q>").slice(2, 8)
     end
   end
 end

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -25,13 +25,14 @@ module ULID
         @time = start.time
         @seed = start.seed
       when NilClass, Time
-        @time = (start || Time.now).utc
-        if seed == nil
+        @time = start || Time.now
+        if seed.nil?
           @seed = random_bytes
         else
           if seed.size != 10 || seed.encoding != Encoding::ASCII_8BIT
             raise ArgumentError.new("seed error, seed value must be 10 bytes encoded as Encoding::ASCII_8BIT")
           end
+
           @seed = seed
         end
       when String
@@ -41,12 +42,12 @@ module ULID
 
         # parse string into bytes
         @ulid = start.upcase
-        @bytes = decode(@ulid)
+        @bytes = decode32(@ulid)
 
         @time, @seed = unpack_decoded_bytes(@bytes)
       else
         # unrecognized initial values type given, just generate fresh ULID
-        @time = Time.now.utc
+        @time = Time.now
         @seed = random_bytes
       end
 

--- a/lib/ulid/parse.rb
+++ b/lib/ulid/parse.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ulid/constants'
 
 module ULID
@@ -6,53 +8,16 @@ module ULID
 
     # v should be a Base32 encoded ULID string. This method decodes it into a
     # 16 byte raw ULID with 48 bit time and 64 bit random parts.
-    def decode(v)
-      out = []
-
-      # hand optimized, unrolled ULID-Base32 format decoder based on
-      # https://github.com/oklog/ulid/blob/c3c01856f7e43fa64133819126887124d5f05e39/ulid.go#L234
-
-      # 6 bytes timestamp (48 bits)
-      out << ((B32REF[v[0]] << 5) |  B32REF[v[1]])
-      out << ((B32REF[v[2]] << 3) | (B32REF[v[3]] >> 2))
-      out << ((B32REF[v[3]] << 6) | (B32REF[v[4]] << 1) | (B32REF[v[5]] >> 4))
-      out << ((B32REF[v[5]] << 4) | (B32REF[v[6]] >> 1))
-      out << ((B32REF[v[6]] << 7) | (B32REF[v[7]] << 2) | (B32REF[v[8]] >> 3))
-      out << ((B32REF[v[8]] << 5) |  B32REF[v[9]])
-
-      # 10 bytes of entropy (80 bits)
-      out << ((B32REF[v[10]] << 3) | (B32REF[v[11]] >> 2))
-      out << ((B32REF[v[11]] << 6) | (B32REF[v[12]] << 1) | (B32REF[v[13]] >> 4))
-      out << ((B32REF[v[13]] << 4) | (B32REF[v[14]] >> 1))
-      out << ((B32REF[v[14]] << 7) | (B32REF[v[15]] << 2) | (B32REF[v[16]] >> 3))
-      out << ((B32REF[v[16]] << 5) | B32REF[v[17]])
-      out << ((B32REF[v[18]] << 3) | B32REF[v[19]]>>2)
-      out << ((B32REF[v[19]] << 6) | (B32REF[v[20]] << 1) | (B32REF[v[21]] >> 4))
-      out << ((B32REF[v[21]] << 4) | (B32REF[v[22]] >> 1))
-      out << ((B32REF[v[22]] << 7) | (B32REF[v[23]] << 2) | (B32REF[v[24]] >> 3))
-      out << ((B32REF[v[24]] << 5) | B32REF[v[25]])
-
-      # get the array as a string, coercing each value to a single byte
-      out = out.pack('C' * 16)
-
-      out
+    def decode32(input)
+      value = Integer(input.tr(B32_CROCKFORD_FRAGMENT, B32_RCF4648_FRAGMENT).downcase, 32)
+      [value >> 64, value & 0xFFFFFFFFFFFFFFFF].pack("Q>Q>")
     end
 
     def unpack_decoded_bytes(packed_bytes)
-      time_bytes = packed_bytes[0..5].bytes.map(&:to_i)
+      time_int = ("\x00\x00#{packed_bytes}").unpack1("Q>")
       seed = packed_bytes[6..-1]
 
-      # and unpack it immedieately into the original milliseconds timestamp
-      # via https://github.com/oklog/ulid/blob/c3c01856f7e43fa64133819126887124d5f05e39/ulid.go#L265
-      time_int = time_bytes[5].to_i |
-        (time_bytes[4].to_i << 8) |
-        (time_bytes[3].to_i << 16) |
-        (time_bytes[2].to_i << 24) |
-        (time_bytes[1].to_i << 32) |
-        (time_bytes[0].to_i << 40)
-
-      [ Time.at( time_int * 1/1000r ).utc, seed ]
+      [Time.at(time_int.to_f / 1000.0), seed]
     end
-
   end
 end

--- a/spec/ulid_spec.rb
+++ b/spec/ulid_spec.rb
@@ -26,7 +26,7 @@ describe ULID do
 
     it 'handles timestamp as the milliseconds precision' do
       expect(ULID.at(Time.parse('2016-07-30 22:36:16.001000000 UTC'))).to start_with('01ARYZ6RR1')
-      expect(ULID.at(Time.parse('2016-07-30 22:36:16.002000000 UTC'))).to start_with('01ARYZ6RR2')
+      expect(ULID.at(Time.parse('2016-07-30 22:36:16.002000001 UTC'))).to(start_with('01ARYZ6RR2')) # leap nanosecond
       expect(ULID.at(Time.parse('2016-07-30 22:36:16.003000000 UTC'))).to start_with('01ARYZ6RR3')
     end
 
@@ -46,7 +46,9 @@ describe ULID do
     it 'handles timestamp as the milliseconds precision' do
       time = ULID.time('0A000000000000000000000000')
       expect(time.to_i).to eq(10995116277)
-      expect(time.nsec).to eq(760000000)
+
+      # ULID precision is only to the millisecond value. Some parses will infer leap nanoseconds
+      expect(time.nsec).to be_within(1000).of(760000000)
     end
   end
 


### PR DESCRIPTION
This PR focuses on optimizing the memory allocation for the byte manipulation to and from the Rockford Base32 encoding and bytes. Specifically the encode32 and decode32 can better utilize the standard rfc4648 base32 encoding for better performance. 

Encoding performance:
```
Calculating -------------------------------------
   encode32_baseline    321.385k (± 1.8%) i/s -      1.612M in   5.016794s
  encode32_optimized      1.100M (± 6.3%) i/s -      5.542M in   5.074883s
     encode32rfc4648      1.894M (± 2.4%) i/s -      9.512M in   5.025403s

Comparison:
     encode32rfc4648:  1893996.2 i/s
  encode32_optimized:  1099515.7 i/s - 1.72x  (± 0.00) slower
   encode32_baseline:   321385.0 i/s - 5.89x  (± 0.00) slower

Calculating -------------------------------------
   encode32_baseline     1.336k memsize (     0.000  retained)
                        29.000  objects (     0.000  retained)
                        18.000  strings (     0.000  retained)
  encode32_optimized   479.000  memsize (    80.000  retained)
                        10.000  objects (     2.000  retained)
                         4.000  strings (     0.000  retained)
     encode32rfc4648   373.000  memsize (    80.000  retained)
                         8.000  objects (     2.000  retained)
                         3.000  strings (     0.000  retained)

Comparison:
     encode32rfc4648:        373 allocated
  encode32_optimized:        479 allocated - 1.28x more
   encode32_baseline:       1336 allocated - 3.58x more
```

Decoding performance:
```
Calculating -------------------------------------
   decode32_baseline    243.968k (± 2.4%) i/s -      1.240M in   5.084222s
  decode32_optimized      1.310M (± 9.4%) i/s -      6.722M in   5.218875s

Comparison:
  decode32_optimized:  1310294.2 i/s
   decode32_baseline:   243967.9 i/s - 5.37x  (± 0.00) slower

Calculating -------------------------------------
   decode32_baseline     1.800k memsize (     0.000  retained)
                        41.000  objects (     0.000  retained)
                        18.000  strings (     0.000  retained)
  decode32_optimized   267.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)

Comparison:
  decode32_optimized:        267 allocated
   decode32_baseline:       1800 allocated - 6.74x more
```

Also even simple time parsing can be optimized:
```
Calculating -------------------------------------
 time_parse_baseline      1.001M (± 7.3%) i/s -      5.007M in   5.051415s
time_parse_optimized      2.122M (± 7.4%) i/s -     10.511M in   5.028573s

Comparison:
time_parse_optimized:  2121531.7 i/s
 time_parse_baseline:  1000624.8 i/s - 2.12x  (± 0.00) slower

Calculating -------------------------------------
 time_parse_baseline   462.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
      time_parse_new   286.000  memsize (    40.000  retained)
                         6.000  objects (     1.000  retained)
                         2.000  strings (     0.000  retained)

Comparison:
      time_parse_new:        286 allocated
 time_parse_baseline:        462 allocated - 1.62x more
```