### PR TITLE
[Fork Merge] Optimize ULID Encodings & Cleanup Coercions

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -55,7 +55,7 @@ module ULID
   #   ULID.time '0009A0QS00SGEFTGMFFEAS6B9A' #=> 1970-04-26 17:46:40 UTC
   #
   def self.time(ulid)
-    Identifier.new(ulid).time.utc
+    Identifier.new(ulid).time
   end
 
   # Get the first possible ULID string for the given time in sort order ascending.
@@ -83,4 +83,3 @@ module ULID
   end
 
 end
-

--- a/lib/ulid/constants.rb
+++ b/lib/ulid/constants.rb
@@ -24,7 +24,7 @@ module ULID
     # B32_CROCKFORD_CHARS = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
     # B32_RCF4648_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
 
-    B32_CROCKFORD_FRAGMENT = "JKMNPQRSTVWXYZ".upcase.freeze
-    B32_RCF4648_FRAGMENT = "IJKLMNOPQRSTUV".downcase.freeze # forcing downcase becase .to_s(32) is always lowercase
+    B32_CROCKFORD_FRAGMENT = "JKMNPQRSTVWXYZ"
+    B32_RCF4648_FRAGMENT = "ijklmnopqrstuv" # downcase because .to_s(32) is always lowercase
   end
 end

--- a/lib/ulid/constants.rb
+++ b/lib/ulid/constants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ULID
   module Constants
     # smallest representable time
@@ -10,12 +12,19 @@ module ULID
     # largest possible seed value
     MAX_ENTROPY = ([255] * 10).pack('C' * 10)
 
-    # Crockford's Base32. Alphabet portion is missing I, L, O, and U.
-    ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    # Crockford's Base32 (https://www.crockford.com/base32.html) Differs from Base32 in the following ways:
+    # * Excludes I, L, O and U
+    # * Aliases O to 0
+    # * Aliases I and L to 1
+    # * Uses U * ~ $ and = for appended checksums
+    #
+    # For simplicity, we use the RFC4648 Base32 encoding and convert to Crockford's Base32 with a simple translate
+    # However, we aren't supporting checksums nor the aliased characters
+    #
+    # B32_CROCKFORD_CHARS = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    # B32_RCF4648_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
 
-    # Byte to index table for O(1) lookups when unmarshaling.
-    # We rely on nil as sentinel value for invalid indexes.
-    B32REF = Hash[ ENCODING.split('').each_with_index.to_a ]
+    B32_CROCKFORD_FRAGMENT = "JKMNPQRSTVWXYZ".upcase.freeze
+    B32_RCF4648_FRAGMENT = "IJKLMNOPQRSTUV".downcase.freeze # forcing downcase becase .to_s(32) is always lowercase
   end
 end
-

--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -1,84 +1,35 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 require 'ulid/constants'
 
 module ULID
-
   module Generate
     include Constants
 
     # returns the binary ULID as Base32 encoded string.
     def encode32
-      # Optimized unrolled loop ahead.
-      # From https://github.com/RobThree/NUlid
-      # via https://github.com/oklog/ulid/blob/c3c01856f7e43fa64133819126887124d5f05e39/ulid.go#L154
+      (hi, lo) = bytes.unpack("Q>Q>")
+      value = (hi << 64) | lo
 
-      id = @bytes.bytes
+      # use the RFC4648 Base32 encoding and convert to Crockford's Base32 with a simple translate
+      # assumes that the value is a 128-bit integer
+      # also assumes that .to_s(32) is lowercase
+      b32 = value.to_s(32).tr!(B32_RCF4648_FRAGMENT, B32_CROCKFORD_FRAGMENT).upcase!
 
-      output = ''
+      return "0" + b32 if b32.length == 25
 
-      # Base32 encodes 5 bits of each byte of the input in each byte of the
-      # output. That means each input byte produces >1 output byte and some
-      # output bytes encode parts of multiple input bytes.
-      #
-      # The end result is a human / URL friendly output string that can be
-      # decoded into the original bytes.
-
-      # 10 byte timestamp
-      output << ENCODING[(id[0]&224)>>5]
-      output << ENCODING[id[0]&31]
-      output << ENCODING[(id[1]&248)>>3]
-      output << ENCODING[((id[1]&7)<<2)|((id[2]&192)>>6)]
-      output << ENCODING[(id[2]&62)>>1]
-      output << ENCODING[((id[2]&1)<<4)|((id[3]&240)>>4)]
-      output << ENCODING[((id[3]&15)<<1)|((id[4]&128)>>7)]
-      output << ENCODING[(id[4]&124)>>2]
-      output << ENCODING[((id[4]&3)<<3)|((id[5]&224)>>5)]
-      output << ENCODING[id[5]&31]
-
-      # 16 bytes of entropy
-      output << ENCODING[(id[6]&248)>>3]
-      output << ENCODING[((id[6]&7)<<2)|((id[7]&192)>>6)]
-      output << ENCODING[(id[7]&62)>>1]
-      output << ENCODING[((id[7]&1)<<4)|((id[8]&240)>>4)]
-      output << ENCODING[((id[8]&15)<<1)|((id[9]&128)>>7)]
-      output << ENCODING[(id[9]&124)>>2]
-      output << ENCODING[((id[9]&3)<<3)|((id[10]&224)>>5)]
-      output << ENCODING[id[10]&31]
-      output << ENCODING[(id[11]&248)>>3]
-      output << ENCODING[((id[11]&7)<<2)|((id[12]&192)>>6)]
-      output << ENCODING[(id[12]&62)>>1]
-      output << ENCODING[((id[12]&1)<<4)|((id[13]&240)>>4)]
-      output << ENCODING[((id[13]&15)<<1)|((id[14]&128)>>7)]
-      output << ENCODING[(id[14]&124)>>2]
-      output << ENCODING[((id[14]&3)<<3)|((id[15]&224)>>5)]
-      output << ENCODING[id[15]&31]
-
-      output
+      b32
     end
 
     def random_bytes
       SecureRandom.random_bytes(10)
     end
 
-    def millisecond_time
-      (@time.to_r * 1_000).to_i
-    end
-
     # THIS IS CORRECT (to the ULID spec)
     def time_bytes
-      id = []
-
-      t = millisecond_time
-
-      # via https://github.com/oklog/ulid/blob/c3c01856f7e43fa64133819126887124d5f05e39/ulid.go#L295
-      id << [t >> 40].pack('c')
-      id << [t >> 32].pack('c')
-      id << [t >> 24].pack('c')
-      id << [t >> 16].pack('c')
-      id << [t >> 8].pack('c')
-      id << [t].pack('c')
-
-      id.join
+      epoch_ms = (time.to_f * 1000).to_i
+      [epoch_ms].pack("Q>").slice(2, 8)
     end
   end
 end

--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -9,8 +9,9 @@ module ULID
 
     # returns the binary ULID as Base32 encoded string.
     def encode32
-      (hi, lo) = bytes.unpack("Q>Q>")
-      value = (hi << 64) | lo
+      high = bytes.unpack1("Q>")
+      low = bytes.unpack1("@8Q>")
+      value = (high << 64) | low
 
       # use the RFC4648 Base32 encoding and convert to Crockford's Base32 with a simple translate
       # assumes that the value is a 128-bit integer
@@ -19,7 +20,7 @@ module ULID
       b32.tr!(B32_RCF4648_FRAGMENT, B32_CROCKFORD_FRAGMENT)
       b32.upcase!
 
-      return "0" + b32 if b32.length == 25
+      return "0#{b32}" if b32.length == 25
 
       b32
     end

--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -56,6 +56,16 @@ module ULID
       output
     end
 
+    # returns the binary uint128 in base16 UUID format
+    def encode16
+      self.bytes.unpack("H8H4H4H4H*").join("-")
+    end
+
+    def encode10
+      (hi, lo) = self.bytes.unpack('Q>Q>')
+      (hi << 64) | lo
+    end
+
     def random_bytes
       SecureRandom.random_bytes(10)
     end

--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -15,7 +15,9 @@ module ULID
       # use the RFC4648 Base32 encoding and convert to Crockford's Base32 with a simple translate
       # assumes that the value is a 128-bit integer
       # also assumes that .to_s(32) is lowercase
-      b32 = value.to_s(32).tr!(B32_RCF4648_FRAGMENT, B32_CROCKFORD_FRAGMENT).upcase!
+      b32 = value.to_s(32)
+      b32.tr!(B32_RCF4648_FRAGMENT, B32_CROCKFORD_FRAGMENT)
+      b32.upcase!
 
       return "0" + b32 if b32.length == 25
 

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -84,13 +84,19 @@ module ULID
       @ulid ||= encode32
     end
 
-    def uuid
+    def to_uuid
       @uuid ||= encode16
     end
 
-    def int128
+    def to_i
       @int128 ||= encode10
     end
+
+    alias_method :to_s, :ulid
+    alias_method :to_str, :ulid
+    alias_method :b, :bytes
+    alias_method :to_int, :to_i
+    alias_method :to_a, :bytes.bytes
 
   end
 end

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -25,7 +25,7 @@ module ULID
         @time = start.time
         @seed = start.seed
       when NilClass, Time
-        @time = (start || Time.now).utc
+        @time = (start || Time.now)
         if seed == nil
           @seed = random_bytes
         else
@@ -69,7 +69,7 @@ module ULID
         @time, @seed = unpack_ulid_bytes(@bytes)
       else
         # unrecognized initial values type given, just generate fresh ULID
-        @time = Time.now.utc
+        @time = Time.now
         @seed = random_bytes
       end
 

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -69,7 +69,7 @@ module ULID
         @time, @seed = unpack_ulid_bytes(@bytes)
       else
         # unrecognized initial values type given, just generate fresh ULID
-        @time = Time.now.utc
+        @time = Time.now
         @seed = random_bytes
       end
 

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -52,14 +52,14 @@ module ULID
 
         raise ArgumentError.new("invalid ULID or UUID") if @bytes.size != 16
 
-        @time, @seed = unpack_decoded_bytes(@bytes)
+        @time, @seed = unpack_ulid_bytes(@bytes)
       when Integer
         # parse integer (BigNum) into bytes
         @bytes = decode10(start)
 
         raise ArgumentError.new("invalid ULID or UUID") if @bytes.size != 16
 
-        @time, @seed = unpack_decoded_bytes(@bytes)
+        @time, @seed = unpack_ulid_bytes(@bytes)
       when Array
         # parse Array(16) into bytes
         @bytes = start.pack("C*")

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -92,11 +92,14 @@ module ULID
       @int128 ||= encode10
     end
 
+    def to_a
+      bytes.bytes
+    end
+
     alias_method :to_s, :ulid
     alias_method :to_str, :ulid
     alias_method :b, :bytes
     alias_method :to_int, :to_i
-    alias_method :to_a, :bytes.bytes
 
   end
 end

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -69,7 +69,7 @@ module ULID
         @time, @seed = unpack_ulid_bytes(@bytes)
       else
         # unrecognized initial values type given, just generate fresh ULID
-        @time = Time.now
+        @time = Time.now.utc
         @seed = random_bytes
       end
 

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -8,7 +8,7 @@ module ULID
     include Generate
     include Compare
 
-    attr_reader :seed, :bytes, :time, :ulid
+    attr_reader :seed, :bytes, :time
 
     # Create a new instance of a ULID::Identifier.
     #
@@ -35,13 +35,36 @@ module ULID
           @seed = seed
         end
       when String
-        if start.size != 26
-          raise ArgumentError.new("invalid ULID string, must be 26 characters")
+        case start.size
+        when 16
+          # assume byte form of ULID (Should be Encoding::ASCII_8BIT)
+          @bytes = start.b
+        when 26
+          # parse ULID string into bytes
+          @ulid = start.upcase
+          @bytes = decode(@ulid)
+        when 36
+          # parse UUID string into bytes
+          @bytes = decode16(start)
+        else
+          raise ArgumentError.new("invalid ULID or UUID string - must be 16, 26, or 36 characters")
         end
 
-        # parse string into bytes
-        @ulid = start.upcase
-        @bytes = decode(@ulid)
+        raise ArgumentError.new("invalid ULID or UUID") if @bytes.size != 16
+
+        @time, @seed = unpack_decoded_bytes(@bytes)
+      when Integer
+        # parse integer (BigNum) into bytes
+        @bytes = decode10(start)
+
+        raise ArgumentError.new("invalid ULID or UUID") if @bytes.size != 16
+
+        @time, @seed = unpack_decoded_bytes(@bytes)
+      when Array
+        # parse Array(16) into bytes
+        @bytes = start.pack("C*")
+
+        raise ArgumentError.new("invalid Byte Array") if @bytes.size != 16
 
         @time, @seed = unpack_decoded_bytes(@bytes)
       else
@@ -54,11 +77,20 @@ module ULID
         # an ASCII_8BIT encoded string, should be 16 bytes
         @bytes = time_bytes + @seed
       end
-
-      if @ulid.nil?
-        # the lexically sortable Base32 string we actually care about
-        @ulid = encode32
-      end
     end
+
+    def ulid
+        # the lexically sortable Base32 string we actually care about
+      @ulid ||= encode32
+    end
+
+    def uuid
+      @uuid ||= encode16
+    end
+
+    def int128
+      @int128 ||= encode10
+    end
+
   end
 end

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -41,9 +41,9 @@ module ULID
 
         # parse string into bytes
         @ulid = start.upcase
-        @bytes = decode(@ulid)
+        @bytes = decode32(@ulid)
 
-        @time, @seed = unpack_decoded_bytes(@bytes)
+        @time, @seed = unpack_ulid_bytes(@bytes)
       else
         # unrecognized initial values type given, just generate fresh ULID
         @time = Time.now.utc

--- a/lib/ulid/parse.rb
+++ b/lib/ulid/parse.rb
@@ -38,6 +38,14 @@ module ULID
       out
     end
 
+    def decode16(input)
+      [input.delete("-")].pack("H*")
+    end
+
+    def decode10(input)
+      [input >> 64, input & 0xFFFFFFFFFFFFFFFF].pack("Q>Q>")
+    end
+
     def unpack_decoded_bytes(packed_bytes)
       time_bytes = packed_bytes[0..5].bytes.map(&:to_i)
       seed = packed_bytes[6..-1]

--- a/lib/ulid/parse.rb
+++ b/lib/ulid/parse.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ulid/constants'
 
 module ULID
@@ -6,53 +8,16 @@ module ULID
 
     # v should be a Base32 encoded ULID string. This method decodes it into a
     # 16 byte raw ULID with 48 bit time and 64 bit random parts.
-    def decode(v)
-      out = []
-
-      # hand optimized, unrolled ULID-Base32 format decoder based on
-      # https://github.com/oklog/ulid/blob/c3c01856f7e43fa64133819126887124d5f05e39/ulid.go#L234
-
-      # 6 bytes timestamp (48 bits)
-      out << ((B32REF[v[0]] << 5) |  B32REF[v[1]])
-      out << ((B32REF[v[2]] << 3) | (B32REF[v[3]] >> 2))
-      out << ((B32REF[v[3]] << 6) | (B32REF[v[4]] << 1) | (B32REF[v[5]] >> 4))
-      out << ((B32REF[v[5]] << 4) | (B32REF[v[6]] >> 1))
-      out << ((B32REF[v[6]] << 7) | (B32REF[v[7]] << 2) | (B32REF[v[8]] >> 3))
-      out << ((B32REF[v[8]] << 5) |  B32REF[v[9]])
-
-      # 10 bytes of entropy (80 bits)
-      out << ((B32REF[v[10]] << 3) | (B32REF[v[11]] >> 2))
-      out << ((B32REF[v[11]] << 6) | (B32REF[v[12]] << 1) | (B32REF[v[13]] >> 4))
-      out << ((B32REF[v[13]] << 4) | (B32REF[v[14]] >> 1))
-      out << ((B32REF[v[14]] << 7) | (B32REF[v[15]] << 2) | (B32REF[v[16]] >> 3))
-      out << ((B32REF[v[16]] << 5) | B32REF[v[17]])
-      out << ((B32REF[v[18]] << 3) | B32REF[v[19]]>>2)
-      out << ((B32REF[v[19]] << 6) | (B32REF[v[20]] << 1) | (B32REF[v[21]] >> 4))
-      out << ((B32REF[v[21]] << 4) | (B32REF[v[22]] >> 1))
-      out << ((B32REF[v[22]] << 7) | (B32REF[v[23]] << 2) | (B32REF[v[24]] >> 3))
-      out << ((B32REF[v[24]] << 5) | B32REF[v[25]])
-
-      # get the array as a string, coercing each value to a single byte
-      out = out.pack('C' * 16)
-
-      out
+    def decode32(input)
+      value = Integer(input.tr(B32_CROCKFORD_FRAGMENT, B32_RCF4648_FRAGMENT).downcase, 32)
+      [value >> 64, value & 0xFFFFFFFFFFFFFFFF].pack("Q>Q>")
     end
 
-    def unpack_decoded_bytes(packed_bytes)
-      time_bytes = packed_bytes[0..5].bytes.map(&:to_i)
+    def unpack_ulid_bytes(packed_bytes)
+      time_int, _ = ("\x00\x00" + packed_bytes).unpack("Q>")
       seed = packed_bytes[6..-1]
 
-      # and unpack it immedieately into the original milliseconds timestamp
-      # via https://github.com/oklog/ulid/blob/c3c01856f7e43fa64133819126887124d5f05e39/ulid.go#L265
-      time_int = time_bytes[5].to_i |
-        (time_bytes[4].to_i << 8) |
-        (time_bytes[3].to_i << 16) |
-        (time_bytes[2].to_i << 24) |
-        (time_bytes[1].to_i << 32) |
-        (time_bytes[0].to_i << 40)
-
-      [ Time.at( time_int * 1/1000r ).utc, seed ]
+      [Time.at(time_int.to_f / 1000.0), seed]
     end
-
   end
 end

--- a/lib/ulid/parse.rb
+++ b/lib/ulid/parse.rb
@@ -22,7 +22,7 @@ module ULID
     end
 
     def unpack_ulid_bytes(packed_bytes)
-      time_int, _ = ("\x00\x00" + packed_bytes).unpack("Q>")
+      time_int = ("\x00\x00#{packed_bytes}").unpack1("Q>")
       seed = packed_bytes[6..-1]
 
       [Time.at(time_int.to_f / 1000.0), seed]

--- a/lib/ulid/version.rb
+++ b/lib/ulid/version.rb
@@ -1,4 +1,3 @@
 module ULID
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end
-

--- a/lib/ulid/version.rb
+++ b/lib/ulid/version.rb
@@ -1,3 +1,3 @@
 module ULID
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/lib/ulid/version.rb
+++ b/lib/ulid/version.rb
@@ -1,4 +1,4 @@
 module ULID
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end
 

--- a/spec/ulid_spec.rb
+++ b/spec/ulid_spec.rb
@@ -81,10 +81,10 @@ describe ULID do
     end
   end
 
-  describe '.uuid' do
+  describe '.to_uuid' do
     it 'generates a valid UUID' do
       ulid = ULID.new KNOWN_STRING
-      expect(ulid.uuid).to eq(KNOWN_UUID)
+      expect(ulid.to_uuid).to eq(KNOWN_UUID)
     end
   end
 
@@ -196,7 +196,7 @@ describe ULID do
 
       it 'supports UUID self generated' do
         first = ULID.new
-        other = ULID.new first.uuid
+        other = ULID.new first.to_uuid
 
         expect(other.ulid).to eq(first.ulid)
         expect(other.seed).to eq(first.seed)
@@ -208,7 +208,7 @@ describe ULID do
     context 'with uInt128 arg' do
       it 'supports BigNum' do
         first = ULID.new
-        other = ULID.new first.int128
+        other = ULID.new first.to_i
 
         expect(other.ulid).to eq(first.ulid)
         expect(other.seed).to eq(first.seed)

--- a/spec/ulid_spec.rb
+++ b/spec/ulid_spec.rb
@@ -26,7 +26,7 @@ describe ULID do
 
     it 'handles timestamp as the milliseconds precision' do
       expect(ULID.at(Time.parse('2016-07-30 22:36:16.001000000 UTC'))).to start_with('01ARYZ6RR1')
-      expect(ULID.at(Time.parse('2016-07-30 22:36:16.002000000 UTC'))).to start_with('01ARYZ6RR2')
+      expect(ULID.at(Time.parse('2016-07-30 22:36:16.002000001 UTC'))).to(start_with('01ARYZ6RR2')) # leap nanosecond
       expect(ULID.at(Time.parse('2016-07-30 22:36:16.003000000 UTC'))).to start_with('01ARYZ6RR3')
     end
 
@@ -46,7 +46,9 @@ describe ULID do
     it 'handles timestamp as the milliseconds precision' do
       time = ULID.time('0A000000000000000000000000')
       expect(time.to_i).to eq(10995116277)
-      expect(time.nsec).to eq(760000000)
+
+      # ULID precision is only to the millisecond value. Some parses will infer leap nanoseconds
+      expect(time.nsec).to be_within(1000).of(760000000)
     end
   end
 

--- a/spec/ulid_spec.rb
+++ b/spec/ulid_spec.rb
@@ -4,8 +4,11 @@ require "spec_helper"
 #               --------------------------
 #               0DHWZ1DT60
 #                         60ZVCSJFXBTG0J2N
-KNOWN_STRING = '01ARYZ6RR0T8CNRGXPSBZSA1PY'
-KNOWN_TIME = Time.parse('2016-07-30 22:36:16 UTC')
+KNOWN_STRING = "01ARYZ6RR0T8CNRGXPSBZSA1PY"
+KNOWN_TIME = Time.parse("2016-07-30 22:36:16 UTC")
+KNOWN_UUID = "01563df3-6300-d219-5c43-b6caff9506de"
+KNOWN_BYTES = "\x01V=\xF3c\x00\xD2\x19\\C\xB6\xCA\xFF\x95\x06\xDE".b
+KNOWN_UINT128 = 1777022035688232904178850488005232350
 
 describe ULID do
   it "has a version number" do
@@ -76,6 +79,21 @@ describe ULID do
     end
   end
 
+  describe '.uuid' do
+    it 'generates a valid UUID' do
+      ulid = ULID.new KNOWN_STRING
+      expect(ulid.uuid).to eq(KNOWN_UUID)
+    end
+  end
+
+  describe '.bytes' do
+    it 'from a valid UUID' do
+      ulid = ULID.new KNOWN_UUID
+      expect(ulid.bytes).to eq(KNOWN_BYTES)
+    end
+  end
+
+
   describe ULID::Identifier do
     context 'with no initialization value' do
       it 'generates a random value for the current time' do
@@ -127,6 +145,78 @@ describe ULID do
       it 'generates with lowercase alphabet' do
         first = ULID.new KNOWN_STRING
         other = ULID.new KNOWN_STRING.downcase
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to eq(first.time)
+      end
+
+      it 'raises an error for invalid ULID string' do
+        expect { ULID.new("not a valid ULID!") }.to raise_error(ArgumentError)
+        expect { ULID.new("") }.to raise_error(ArgumentError)
+        expect { ULID.new(KNOWN_STRING + KNOWN_STRING) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with Bytes string arg' do
+      it 'supports byteform' do
+        first = ULID.new
+        other = ULID.new first.bytes
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to be_within(0.001).of(first.time)
+      end
+    end
+
+    context 'with UUID string arg' do
+      it 'supports UUID' do
+        first = ULID.new KNOWN_UUID
+        other = ULID.new KNOWN_STRING
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to eq(first.time)
+      end
+
+      it 'supports UUID case insensitive' do
+        first = ULID.new KNOWN_UUID.downcase
+        other = ULID.new KNOWN_UUID.upcase
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to eq(first.time)
+      end
+
+      it 'supports UUID self generated' do
+        first = ULID.new
+        other = ULID.new first.uuid
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to be_within(0.001).of(first.time)
+      end
+    end
+
+    context 'with uInt128 arg' do
+      it 'supports BigNum' do
+        first = ULID.new
+        other = ULID.new first.int128
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to be_within(0.001).of(first.time)
+      end
+
+      it 'supports BigNum self generated' do
+        first = ULID.new KNOWN_UINT128
+        other = ULID.new KNOWN_STRING
 
         expect(other.ulid).to eq(first.ulid)
         expect(other.seed).to eq(first.seed)


### PR DESCRIPTION
Fork merge inclusive of:
- Optimized ULID encodings in https://github.com/abachman/ulid-ruby/pull/10
- Type coercion improvements in https://github.com/abachman/ulid-ruby/pull/11
- Bug fix in  https://github.com/abachman/ulid-ruby/commit/3ba0841933cc737d5bd65bfc9f5398376e9e080f , as well as the small cleanups and version bumps in https://github.com/abachman/ulid-ruby/commit/056a0eb5eee443e0de4184f4b4e9f07e2258ee5d, https://github.com/abachman/ulid-ruby/commit/d365d31746249efa97519a9fd7d4d2bd1c3bf6b2, and https://github.com/abachman/ulid-ruby/commit/de9176113d8a492d4eb657cd32b0ba7466f43de7

Merging this directly would synchronize our internal fork (used directly in a few places) to the open-source gem